### PR TITLE
! DONT MERGE ! Orchestrator test utils with tx await

### DIFF
--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -42,9 +42,9 @@ mod valset_rewards;
 mod valset_stress;
 
 /// the timeout for individual requests
-const OPERATION_TIMEOUT: Duration = Duration::from_secs(120);
+const OPERATION_TIMEOUT: Duration = Duration::from_secs(240);
 /// the timeout for the total system
-const TOTAL_TIMEOUT: Duration = Duration::from_secs(600);
+const TOTAL_TIMEOUT: Duration = Duration::from_secs(900);
 
 // Retrieve values from runtime ENV vars
 lazy_static! {

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -26,7 +26,7 @@ const TIMEOUT: Duration = Duration::from_secs(120);
 /// ERC20 sends = (erc20_addresses.len() * NUM_USERS)
 /// Gravity Deposits = (erc20_addresses.len() * NUM_USERS)
 /// Batches executed = erc20_addresses.len() * (NUM_USERS / 100)
-const NUM_USERS: usize = 40;
+const NUM_USERS: usize = 100;
 
 /// Perform a stress test by sending thousands of
 /// transactions and producing large batches

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -15,7 +15,7 @@ use tokio::time::sleep;
 use tonic::transport::Channel;
 use web30::{client::Web3, types::SendTxOption};
 
-const TIMEOUT: Duration = Duration::from_secs(120);
+const TIMEOUT: Duration = Duration::from_secs(240);
 
 /// The number of users we will be simulating for this test, each user
 /// will get one token from each token type in erc20_addresses and send it

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -15,7 +15,7 @@ use tokio::time::sleep;
 use tonic::transport::Channel;
 use web30::{client::Web3, types::SendTxOption};
 
-const TIMEOUT: Duration = Duration::from_secs(240);
+const TIMEOUT: Duration = Duration::from_secs(120);
 
 /// The number of users we will be simulating for this test, each user
 /// will get one token from each token type in erc20_addresses and send it
@@ -26,7 +26,7 @@ const TIMEOUT: Duration = Duration::from_secs(240);
 /// ERC20 sends = (erc20_addresses.len() * NUM_USERS)
 /// Gravity Deposits = (erc20_addresses.len() * NUM_USERS)
 /// Batches executed = erc20_addresses.len() * (NUM_USERS / 100)
-const NUM_USERS: usize = 100;
+const NUM_USERS: usize = 40;
 
 /// Perform a stress test by sending thousands of
 /// transactions and producing large batches

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -92,6 +92,7 @@ pub async fn send_erc20_bulk(
         .unwrap();
 
     for address in destinations {
+        info!("Sending {} erc20 to {}", amount.clone(), *address);
         let txid = web3
             .erc20_send(
                 amount.clone(),
@@ -129,6 +130,7 @@ pub async fn send_eth_bulk(amount: Uint256, destinations: &[EthAddress], web3: &
         .unwrap();
 
     for address in destinations {
+        info!("Sending {} ETH to {}", amount.clone(), *address);
         let tx = Transaction {
             to: *address,
             nonce: nonce.clone(),

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -12,7 +12,6 @@ use deep_space::coin::Coin;
 use deep_space::private_key::PrivateKey as CosmosPrivateKey;
 use deep_space::utils::encode_any;
 use deep_space::Contact;
-use futures::future::join_all;
 use gravity_proto::cosmos_sdk_proto::cosmos::params::v1beta1::ParamChange;
 use gravity_proto::cosmos_sdk_proto::cosmos::params::v1beta1::ParameterChangeProposal;
 use gravity_proto::gravity::query_client::QueryClient as GravityQueryClient;
@@ -20,7 +19,6 @@ use gravity_utils::types::GravityBridgeToolsConfig;
 use orchestrator::main_loop::orchestrator_main_loop;
 use rand::Rng;
 use std::panic;
-use web30::jsonrpc::error::Web3Error;
 use web30::{client::Web3, types::SendTxOption};
 
 pub fn create_default_test_config() -> GravityBridgeToolsConfig {
@@ -92,31 +90,30 @@ pub async fn send_erc20_bulk(
         .eth_get_transaction_count(*MINER_ADDRESS)
         .await
         .unwrap();
-    let mut transactions = Vec::new();
+
     for address in destinations {
-        let send = web3.erc20_send(
-            amount.clone(),
-            *address,
-            erc20,
-            *MINER_PRIVATE_KEY,
-            Some(OPERATION_TIMEOUT),
-            vec![
-                SendTxOption::Nonce(nonce.clone()),
-                SendTxOption::GasLimit(100_000u32.into()),
-                SendTxOption::GasPriceMultiplier(5.0),
-            ],
-        );
-        transactions.push(send);
+        let txid = web3
+            .erc20_send(
+                amount.clone(),
+                *address,
+                erc20,
+                *MINER_PRIVATE_KEY,
+                Some(OPERATION_TIMEOUT),
+                vec![
+                    SendTxOption::Nonce(nonce.clone()),
+                    SendTxOption::GasLimit(100_000u32.into()),
+                    SendTxOption::GasPriceMultiplier(5.0),
+                ],
+            )
+            .await;
+
+        web3.wait_for_transaction(txid.unwrap(), TOTAL_TIMEOUT, None)
+            .await
+            .unwrap();
+        check_erc20_balance(*address, erc20, amount.clone(), web3).await;
+
         nonce += 1u64.into();
     }
-    let txids = join_all(transactions).await;
-    wait_for_txids(txids, web3).await;
-    let mut balance_checks = Vec::new();
-    for address in destinations {
-        let check = check_erc20_balance(*address, erc20, amount.clone(), web3);
-        balance_checks.push(check);
-    }
-    join_all(balance_checks).await;
 }
 
 /// This function efficiently distributes ETH to a large number of provided Ethereum addresses
@@ -124,14 +121,15 @@ pub async fn send_erc20_bulk(
 /// single address without your sequence getting out of whack. By manually setting the nonce
 /// here we can quickly send thousands of transactions in only a few blocks
 pub async fn send_eth_bulk(amount: Uint256, destinations: &[EthAddress], web3: &Web3) {
+    // type to let the nonce be indexed
     let net_version = web3.net_version().await.unwrap();
     let mut nonce = web3
         .eth_get_transaction_count(*MINER_ADDRESS)
         .await
         .unwrap();
-    let mut transactions = Vec::new();
+
     for address in destinations {
-        let t = Transaction {
+        let tx = Transaction {
             to: *address,
             nonce: nonce.clone(),
             gas_price: HIGH_GAS_PRICE.into(),
@@ -140,26 +138,14 @@ pub async fn send_eth_bulk(amount: Uint256, destinations: &[EthAddress], web3: &
             data: Vec::new(),
             signature: None,
         };
-        let t = t.sign(&*MINER_PRIVATE_KEY, Some(net_version));
-        transactions.push(t);
+        let tx = tx.sign(&*MINER_PRIVATE_KEY, Some(net_version));
+        let txid = web3.eth_send_raw_transaction(tx.to_bytes().unwrap()).await;
+        web3.wait_for_transaction(txid.unwrap(), TOTAL_TIMEOUT, None)
+            .await
+            .unwrap();
+
         nonce += 1u64.into();
     }
-    let mut sends = Vec::new();
-    for tx in transactions {
-        sends.push(web3.eth_send_raw_transaction(tx.to_bytes().unwrap()));
-    }
-    let txids = join_all(sends).await;
-    wait_for_txids(txids, web3).await;
-}
-
-/// utility function that waits for a large number of txids to enter a block
-async fn wait_for_txids(txids: Vec<Result<Uint256, Web3Error>>, web3: &Web3) {
-    let mut wait_for_txid = Vec::new();
-    for txid in txids {
-        let wait = web3.wait_for_transaction(txid.unwrap(), TOTAL_TIMEOUT, None);
-        wait_for_txid.push(wait);
-    }
-    join_all(wait_for_txid).await;
 }
 
 /// utility function for bulk checking erc20 balances, used to provide

--- a/orchestrator/test_runner/src/utils.rs
+++ b/orchestrator/test_runner/src/utils.rs
@@ -130,7 +130,7 @@ pub async fn send_eth_bulk(amount: Uint256, destinations: &[EthAddress], web3: &
         .unwrap();
 
     for address in destinations {
-        info!("Sending {} ETH to {}", amount.clone(), *address);
+        info!("Sending {} wei to {}", amount.clone(), *address);
         let tx = Transaction {
             to: *address,
             nonce: nonce.clone(),

--- a/tests/assets/ETHGenesis.json
+++ b/tests/assets/ETHGenesis.json
@@ -12,7 +12,7 @@
     "berlinBlock": 0,
     "londonBlock": 0
   },
-  "difficulty": "0x400",
+  "difficulty": "0x1",
   "gasLimit": "0xB71B00",
   "alloc": {
     "0xBf660843528035a5A4921534E156a27e64B231fE": {


### PR DESCRIPTION
The prev implementations of the "send_eth_bulk" and "send_erc20_bulk" were based on send_raw_tx + nonce increment and send at the same time. But the problem in such a scenario is that it is not always possible in case the client can't put the txs in the queue and tries to execute them at the same time. It might cause the ERROR with the attempt to submit the tx with the wrong nonce.
The drawback of this implementation is potentially the test time might be increased, but slightly.