### PR TITLE
Local artefact tests with MAC support

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -66,8 +66,8 @@ go.sum: go.mod
 test:
 	@go test -mod=readonly $(PACKAGES)
 
-build-linux:
-	GOOS=linux GOARCH=amd64 go build -o build/gravity $(BUILD_FLAGS) ./cmd/gravity/main.go
+build-linux-amd64:
+	GOOS=linux GOARCH=amd64 go build -o $(BIN_PATH)gravity $(BUILD_FLAGS) ./cmd/gravity/main.go
 
 # look into .golangci.yml for enabling / disabling linters
 lint:
@@ -193,7 +193,6 @@ tools-clean:
 	rm -f proto-tools-stamp buf-stamp
 
 # below are all for the reproducible builder
-
 build-reproducible: go.sum
 	$(DOCKER) rm latest-build || true
 	$(DOCKER) run --volume=$(CURDIR)/.././:/sources:ro \

--- a/orchestrator/.cargo/config
+++ b/orchestrator/.cargo/config
@@ -1,3 +1,6 @@
 [target.x86_64-apple-darwin]
 linker = "x86_64-apple-darwin14-clang"
 ar = "x86_64-apple-darwin14-ar"
+
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ in which case the default behavior will build needed artifacts from scratch in a
 
 The default process takes several minutes which makes development cycles slow. Instead,
 `USE_LOCAL_ARTIFACTS=1` can be prepended (e.x.
-`USE_LOCAL_ARTIFACTS=1 bash tests/all-up-test.sh HAPPY_PATH_V2`). This will cause
+`USE_LOCAL_ARTIFACTS=1 bash all-up-test.sh HAPPY_PATH_V2`). This will cause
 `build-container.sh` to use locally built artifacts. The first build in a clean repository will be
 as slow as the default case, but every build afterwards will reuse the local incremental compilation
 data on the Rust and Go sides.

--- a/tests/all-up-test.sh
+++ b/tests/all-up-test.sh
@@ -3,6 +3,7 @@ set -eux
 # the directory of this script, useful for allowing this script
 # to be run with any PWD
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPOFOLDER=$DIR/..
 
 # builds the container containing various system deps
 # also builds Gravity once in order to cache Go deps, this container
@@ -32,5 +33,12 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
        PLATFORM_CMD="--platform=linux/amd64"; fi
 fi
 
+# use value instead of git archive in case of USE_LOCAL_ARTIFACTS tests
+if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
+   VOLUME_ARGS=""
+else
+   VOLUME_ARGS="-v $REPOFOLDER:/gravity"
+fi
+
 # Run new test container instance
-docker run --name gravity_all_up_test_instance --env USE_LOCAL_ARTIFACTS=${USE_LOCAL_ARTIFACTS:-0} $PLATFORM_CMD --cap-add=NET_ADMIN -t gravity-base /bin/bash /gravity/tests/container-scripts/all-up-test-internal.sh $NODES $TEST_TYPE $ALCHEMY_ID
+docker run --name gravity_all_up_test_instance $VOLUME_ARGS --env USE_LOCAL_ARTIFACTS=${USE_LOCAL_ARTIFACTS:-0} $PLATFORM_CMD --cap-add=NET_ADMIN -t gravity-base /bin/bash /gravity/tests/container-scripts/all-up-test-internal.sh $NODES $TEST_TYPE $ALCHEMY_ID

--- a/tests/build-container.sh
+++ b/tests/build-container.sh
@@ -18,34 +18,25 @@ if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
     # will be uncompressed anyway when added to the container
     git archive --format=tar -o $DOCKERFOLDER/gravity.tar --prefix=gravity/ HEAD
 else
-    # getting the `test-runner` binary
-    pushd $REPOFOLDER/orchestrator/test_runner && PATH=$PATH:$HOME/.cargo/bin cargo build --all --release
-    # getting the `gravity` binary. `GOBIN` is set so that it is placed under `/dockerfile`.
-    # This will be moved to its normal place by the `Dockerfile`.
+    # getting the `test-runner` binary with the x86_64-linux-musl, because the tests will be running on linix
+    pushd $REPOFOLDER/orchestrator && PATH=$PATH:$HOME/.cargo/bin CROSS_COMPILE=x86_64-linux-musl- cargo build --all --release --target=x86_64-unknown-linux-musl
+    # getting the `gravity` binary. `BIN_PATH` is set so that it is placed under `/dockerfile`.
+    # This will be moved to binaries place by the `Dockerfile`.
     pushd $REPOFOLDER/module/ &&
-        PATH=$PATH:/usr/local/go/bin GOPROXY=https://proxy.golang.org make &&
-        PATH=$PATH:/usr/local/go/bin GOBIN=$REPOFOLDER/tests/dockerfile make install
+        PATH=$PATH:/usr/local/go/bin GOPROXY=https://proxy.golang.org go mod vendor &&
+        PATH=$PATH:/usr/local/go/bin LEDGER_ENABLED=false BIN_PATH=$DOCKERFOLDER/ make build-linux-amd64
 
-    # TODO figure out a way to reuse solidity artifacts and deploy contracts,
-    # preferably without bringing all of `node_modules` to the container
-    #pushd $REPOFOLDER/solidity/ &&
-    #HUSKY_SKIP_INSTALL=1 npm install
-    #npm run typechain
+    # build npm artifacts
+    pushd $REPOFOLDER/solidity/ &&
+    HUSKY_SKIP_INSTALL=1 npm ci
+    npm run typechain
 
-    pushd $REPOFOLDER
+    # compress binaries
+    pushd $DOCKERFOLDER
+    tar -cvf gravity.tar gravity
 
-    # because `--add-file` is not available except in very recent versions of `git`,
-    # we cannot add them through the archive command and need to add them to the tar
-    # file ourselves
-    git archive --format=tar -o $DOCKERFOLDER/gravity.tar --prefix=gravity/ HEAD
-    tar --append --file=$DOCKERFOLDER/gravity.tar --transform='s,orchestrator/target/release/test-runner,gravity/orchestrator/target/release/test-runner,' $REPOFOLDER/orchestrator/target/release/test-runner
-    # this is the go binary
-    tar --append --file=$DOCKERFOLDER/gravity.tar --transform='s,tests/dockerfile/gravity,gravity/tests/dockerfile/gravity,' $REPOFOLDER/tests/dockerfile/gravity
-    # solidity artifacts
-    #tar --append --file=$DOCKERFOLDER/gravity.tar --transform='s,solidity/cache,gravity/solidity/cache,' $REPOFOLDER/solidity/cache
-    #tar --append --file=$DOCKERFOLDER/gravity.tar --transform='s,solidity/artifacts,gravity/solidity/artifacts,' $REPOFOLDER/solidity/artifacts
-    #tar --append --file=$DOCKERFOLDER/gravity.tar --transform='s,solidity/typechain,gravity/solidity/typechain,' $REPOFOLDER/solidity/typechain
-    #tar --append --file=$DOCKERFOLDER/gravity.tar --transform='s,solidity/node_modules,gravity/solidity/node_modules,' $REPOFOLDER/solidity/node_modules
+    # clean
+    rm $DOCKERFOLDER/gravity
 fi
 
 pushd $DOCKERFOLDER
@@ -58,3 +49,6 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
        PLATFORM_CMD="--platform=linux/amd64"; fi
 fi
 docker build -t gravity-base $PLATFORM_CMD . --build-arg use_local_artifacts=${USE_LOCAL_ARTIFACTS:-0}
+
+# clear gravity archive
+rm gravity.tar

--- a/tests/container-scripts/all-up-test-internal.sh
+++ b/tests/container-scripts/all-up-test-internal.sh
@@ -5,20 +5,18 @@ TEST_TYPE=$2
 ALCHEMY_ID=$3
 set -eux
 
-# Prepare the contracts for later deployment
-pushd /gravity/solidity/
-HUSKY_SKIP_INSTALL=1 npm install
-npm run typechain
-
-bash /gravity/tests/container-scripts/setup-validators.sh $NODES
-
-bash /gravity/tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE $ALCHEMY_ID &
-
 if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
+    # Prepare the contracts for later deployment
+    pushd /gravity/solidity/
+    HUSKY_SKIP_INSTALL=1 npm ci
+    npm run typechain
     RUN_ARGS="cargo run --release --bin test-runner"
 else
-    RUN_ARGS=/gravity/orchestrator/target/release/test-runner
+    RUN_ARGS=/gravity/orchestrator/target/x86_64-unknown-linux-musl/release/test-runner
 fi
+
+bash /gravity/tests/container-scripts/setup-validators.sh $NODES
+bash /gravity/tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE $ALCHEMY_ID &
 
 # deploy the ethereum contracts
 pushd /gravity/orchestrator/test_runner

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -20,7 +20,7 @@ pushd /gravity/orchestrator/test_runner
 if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
     RUN_ARGS="cargo run --release --bin test-runner"
 else
-    RUN_ARGS=/gravity/orchestrator/target/release/test-runner
+    RUN_ARGS=/gravity/orchestrator/target/x86_64-unknown-linux-musl/release/test-runner
 fi
 
 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS

--- a/tests/container-scripts/reload-code.sh
+++ b/tests/container-scripts/reload-code.sh
@@ -16,23 +16,13 @@ do
     rm -rf "/validator$i"
 done
 
-if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
-    cd /gravity/module/
-    export PATH=$PATH:/usr/local/go/bin
-    make
-    make install
-    RUN_ARGS="cargo run --release --bin test-runner"
-else
-    RUN_ARGS=/gravity/orchestrator/target/release/test-runner
-fi
-
 cd /gravity/
 tests/container-scripts/setup-validators.sh $NODES
 tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE $ALCHEMY_ID
 
 # deploy the ethereum contracts
 pushd /gravity/orchestrator/test_runner
-DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE NO_GAS_OPT=1 RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS
+DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE NO_GAS_OPT=1 RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner
 
 # This keeps the script open to prevent Docker from stopping the container
 # immediately if the nodes are killed by a different process

--- a/tests/dockerfile/Dockerfile
+++ b/tests/dockerfile/Dockerfile
@@ -24,6 +24,5 @@ RUN if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]] ; then \
     && pushd /gravity/solidity/ \
     && npm ci \
 ; else \
-    mkdir -p /go/bin/ \
-    && mv /gravity/tests/dockerfile/gravity /go/bin/gravity \
+    mv gravity /usr/bin/gravity \
 ; fi


### PR DESCRIPTION
The PR contains improvements to run tests with local artifacts on MAC os.  The previous version contained that command to build the artifacts for the current platform and then run them in on Linux. As a result, the tests on MAC were failed.
Also, the PR contains the optimization of the docker image building and uses volumes instead of tar copy. 