### PR TITLE
Make `USE_LOCAL_ARTIFACTS` work on more platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target
 tests/test-runner/Cargo.lock
 tests/dockerfile/gravity.tar
 tests/dockerfile/gravity
+tests/dockerfile/test-runner
 solidity/dist
 orchestrator/bins
 

--- a/orchestrator/.cargo/config
+++ b/orchestrator/.cargo/config
@@ -2,5 +2,6 @@
 linker = "x86_64-apple-darwin14-clang"
 ar = "x86_64-apple-darwin14-ar"
 
+# needed for MacOS compatibility build in `tests/build-container.sh`
 [target.x86_64-unknown-linux-musl]
 linker = "x86_64-linux-musl-gcc"

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,8 +6,7 @@ scripts like `run-tests.sh` after the container has been built with `build-conta
 run with `start-chains.sh`. `all-up-test.sh` and `run-all-test.sh` automatically run the whole
 process from building the container to executing scripts in it.
 
-NOTE: `git archive ... HEAD` is used so that only committed changes will be used, both in the
-default case and with USE_LOCAL_ARTIFACTS.
+NOTE: in the default case, `git archive ... HEAD` is used so that only committed changes will be used.
 
 ## USE_LOCAL_ARTIFACTS
 
@@ -20,3 +19,7 @@ The default process takes several minutes which makes development cycles slow. I
 `build-container.sh` to use locally built artifacts. The first build in a clean repository will be
 as slow as the default case, but every build afterwards will reuse the local incremental compilation
 data on the Rust and Go sides.
+
+One more thing which can reduce build time is to comment out the line below "build npm artifacts"
+in `build-container.sh` (because `npm` is slow at rebuilding when no changes have been made), but
+only do this after the first build after changes to `solidity/`

--- a/tests/container-scripts/all-up-test-internal.sh
+++ b/tests/container-scripts/all-up-test-internal.sh
@@ -12,7 +12,7 @@ if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
     npm run typechain
     RUN_ARGS="cargo run --release --bin test-runner"
 else
-    RUN_ARGS=/gravity/orchestrator/target/x86_64-unknown-linux-musl/release/test-runner
+    RUN_ARGS=/gravity/tests/dockerfile/test-runner
 fi
 
 bash /gravity/tests/container-scripts/setup-validators.sh $NODES

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -20,7 +20,7 @@ pushd /gravity/orchestrator/test_runner
 if [[ "${USE_LOCAL_ARTIFACTS:-0}" -eq "0" ]]; then
     RUN_ARGS="cargo run --release --bin test-runner"
 else
-    RUN_ARGS=/gravity/orchestrator/target/x86_64-unknown-linux-musl/release/test-runner
+    RUN_ARGS=/gravity/tests/dockerfile/test-runner
 fi
 
 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS


### PR DESCRIPTION
For future reference, this was needed because I got loading errors:
```
sh-5.1# ldd ./test-runner
        statically linked
sh-5.1# file ./test-runner
./test-runner: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, with debug_info, not stripped
sh-5.1# ./test-runner
sh: ./test-runner: No such file or directory
sh-5.1#
```
when trying to run `musl` binaries.