### PR TITLE
Emit events erased by the CacheContext

### DIFF
--- a/module/x/gravity/keeper/attestation.go
+++ b/module/x/gravity/keeper/attestation.go
@@ -140,6 +140,7 @@ func (k Keeper) processAttestation(ctx sdk.Context, att *types.Attestation, clai
 		)
 	} else {
 		commit() // persist transient storage
+		ctx.EventManager().EmitEvents(xCtx.EventManager().Events())
 	}
 }
 


### PR DESCRIPTION
The "processAttestation" function contains code where it generates new context by "xCtx, commit := ctx.CacheContext()" and then uses "xCtx" for the "k.AttestationHandler.Handle" to generate a new Tx. The "k.AttestationHandler.Handle" fill the context with the Events during the execution, and then the "processAttestation" commits the state but events that were added to the "xCtx" are not moved to the "ctx" which is used later to get the events. 

This PR contains the fix for that issue.