### PR TITLE
Tokio timeout instead of loops

### DIFF
--- a/orchestrator/gbt/src/client/eth_to_cosmos.rs
+++ b/orchestrator/gbt/src/client/eth_to_cosmos.rs
@@ -62,7 +62,7 @@ pub async fn eth_to_cosmos(args: EthToCosmosOpts, prefix: String) -> Result<(), 
         amount.clone(),
         cosmos_dest,
         ethereum_key,
-        Some(TIMEOUT),
+        TIMEOUT,
         &web3,
         vec![],
     )

--- a/orchestrator/gravity_utils/src/types/ethereum_events.rs
+++ b/orchestrator/gravity_utils/src/types/ethereum_events.rs
@@ -832,8 +832,6 @@ fn _debug_print_data(input: &[u8]) {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
-
     use clarity::utils::hex_str_to_bytes;
     use rand::{
         distributions::{Distribution, Uniform},
@@ -843,8 +841,7 @@ mod tests {
 
     use super::*;
 
-    /// Five minutes fuzzing by default
-    const FUZZ_TIME: Duration = Duration::from_secs(30);
+    const FUZZ_TIMES: u64 = 100_000;
 
     fn get_fuzz_bytes(rng: &mut ThreadRng) -> Vec<u8> {
         let range = Uniform::from(1..200_000);
@@ -926,9 +923,8 @@ mod tests {
 
     #[test]
     fn fuzz_send_to_cosmos_decode() {
-        let start = Instant::now();
         let mut rng = thread_rng();
-        while Instant::now() - start < FUZZ_TIME {
+        for _ in 0..FUZZ_TIMES {
             let event_bytes = get_fuzz_bytes(&mut rng);
 
             let res = SendToCosmosEvent::decode_data_bytes(&event_bytes);
@@ -941,9 +937,8 @@ mod tests {
 
     #[test]
     fn fuzz_valset_updated_event_decode() {
-        let start = Instant::now();
         let mut rng = thread_rng();
-        while Instant::now() - start < FUZZ_TIME {
+        for _ in 0..FUZZ_TIMES {
             let event_bytes = get_fuzz_bytes(&mut rng);
 
             let res = ValsetUpdatedEvent::decode_data_bytes(&event_bytes);
@@ -956,9 +951,8 @@ mod tests {
 
     #[test]
     fn fuzz_erc20_deployed_event_decode() {
-        let start = Instant::now();
         let mut rng = thread_rng();
-        while Instant::now() - start < FUZZ_TIME {
+        for _ in 0..FUZZ_TIMES {
             let event_bytes = get_fuzz_bytes(&mut rng);
 
             let res = Erc20DeployedEvent::decode_data_bytes(&event_bytes);

--- a/orchestrator/test_runner/src/happy_path.rs
+++ b/orchestrator/test_runner/src/happy_path.rs
@@ -368,7 +368,7 @@ pub async fn test_erc20_deposit_result(
         amount.clone(),
         dest,
         *MINER_PRIVATE_KEY,
-        None,
+        OPERATION_TIMEOUT,
         web30,
         vec![],
     )

--- a/orchestrator/test_runner/src/transaction_stress_test.rs
+++ b/orchestrator/test_runner/src/transaction_stress_test.rs
@@ -78,7 +78,7 @@ pub async fn transaction_stress_test(
                 one_hundred_eth(),
                 keys.cosmos_address,
                 keys.eth_key,
-                Some(TIMEOUT),
+                TIMEOUT,
                 web30,
                 vec![SendTxOption::GasPriceMultiplier(5.0)],
             );


### PR DESCRIPTION
Refactor timeout usage

* refactor the usage of Instant::now + loops for operations with timeouts (use tokio::time::timeout instead of Instant::now where possible)
* refactor send_to_cosmos function ti simplify timeout operations
* refactor/fix wait_for_height function to use input args correctly

Resolves #40 