### PR TITLE
Random voting power for the integration tests

### DIFF
--- a/tests/container-scripts/setup-validators.sh
+++ b/tests/container-scripts/setup-validators.sh
@@ -70,7 +70,7 @@ ETHEREUM_KEY=$(grep address /validator-eth-keys | sed -n "$i"p | sed 's/.*://')
 # the /8 containing 7.7.7.7 is assigned to the DOD and never routable on the public internet
 # we're using it in private to prevent gaia from blacklisting it as unroutable
 # and allow local pex
-$BIN gentx $ARGS $GAIA_HOME --moniker validator$i --chain-id=$CHAIN_ID --ip 7.7.7.$i validator$i 500000000000000000000stake $ETHEREUM_KEY $ORCHESTRATOR_KEY
+$BIN gentx $ARGS $GAIA_HOME --moniker validator$i --chain-id=$CHAIN_ID --ip 7.7.7.$i validator$i "$(seq 400 500 | sort -R | head -n 1)""000000000000000000stake" $ETHEREUM_KEY $ORCHESTRATOR_KEY
 # obviously we don't need to copy validator1's gentx to itself
 if [ $i -gt 1 ]; then
 cp /validator$i/config/gentx/* /validator1/config/gentx/


### PR DESCRIPTION
Current integration tests use the same voting power for the validators, but in the real-world bridge, it will be different. So in order to make them close to the real world, the voting power should be different (generated randomly in range). 