### PR TITLE
Don't log valset up to date message

### DIFF
--- a/orchestrator/cosmos_gravity/src/send.rs
+++ b/orchestrator/cosmos_gravity/src/send.rs
@@ -293,9 +293,9 @@ pub async fn send_ethereum_claims(
 
     let msgs: Vec<Msg> = ordered_msgs.into_iter().map(|(_, v)| v).collect();
 
-    Ok(contact
+    contact
         .send_message(&msgs, None, &[fee], Some(TIMEOUT), private_key)
-        .await?)
+        .await
 }
 
 /// Sends tokens from Cosmos to Ethereum. These tokens will not be sent immediately instead

--- a/orchestrator/relayer/src/valset_relaying.rs
+++ b/orchestrator/relayer/src/valset_relaying.rs
@@ -60,6 +60,9 @@ pub async fn relay_valsets(
     .await
     {
         Ok(v) => v,
+        // If we get the RecoverableError we don't need to log it, since it is a kind of flag to indicate that it was expected.
+        // And here we expect the ValsetUpToDate error which means that we don't need to update up to date valset.
+        Err(GravityError::RecoverableError(_)) => return,
         Err(e) => {
             error!(
                 "We were unable to find a valid validator set update to submit! {:?}",


### PR DESCRIPTION
Don't log valset up to date message since it is expected to handle this error, and it's not even an error it's just a flag to say that we are in sync.
The corresponding code of the original gravity-bridge: https://github.com/Gravity-Bridge/Gravity-Bridge/blob/main/orchestrator/relayer/src/valset_relaying.rs#L62