### PR TITLE
onomy sdk integration

### DIFF
--- a/module/app/app.go
+++ b/module/app/app.go
@@ -219,33 +219,75 @@ type Gravity struct {
 
 // ValidateMembers checks for nil members
 func (app Gravity) ValidateMembers() {
-	if app.legacyAmino == nil { panic("Nil legacyAmino!") }
+	if app.legacyAmino == nil {
+		panic("Nil legacyAmino!")
+	}
 
 	// keepers
-	if app.accountKeeper     == nil { panic("Nil accountKeeper!") }
-	if app.authzKeeper       == nil { panic("Nil authzKeeper!") }
-	if app.bankKeeper        == nil { panic("Nil bankKeeper!") }
-	if app.capabilityKeeper  == nil { panic("Nil capabilityKeeper!") }
-	if app.stakingKeeper     == nil { panic("Nil stakingKeeper!") }
-	if app.slashingKeeper    == nil { panic("Nil slashingKeeper!") }
-	if app.mintKeeper        == nil { panic("Nil mintKeeper!") }
-	if app.distrKeeper       == nil { panic("Nil distrKeeper!") }
-	if app.govKeeper         == nil { panic("Nil govKeeper!") }
-	if app.crisisKeeper      == nil { panic("Nil crisisKeeper!") }
-	if app.upgradeKeeper     == nil { panic("Nil upgradeKeeper!") }
-	if app.paramsKeeper      == nil { panic("Nil paramsKeeper!") }
-	if app.ibcKeeper         == nil { panic("Nil ibcKeeper!") }
-	if app.evidenceKeeper    == nil { panic("Nil evidenceKeeper!") }
-	if app.ibcTransferKeeper == nil { panic("Nil ibcTransferKeeper!") }
-	if app.gravityKeeper     == nil { panic("Nil gravityKeeper!") }
+	if app.accountKeeper == nil {
+		panic("Nil accountKeeper!")
+	}
+	if app.authzKeeper == nil {
+		panic("Nil authzKeeper!")
+	}
+	if app.bankKeeper == nil {
+		panic("Nil bankKeeper!")
+	}
+	if app.capabilityKeeper == nil {
+		panic("Nil capabilityKeeper!")
+	}
+	if app.stakingKeeper == nil {
+		panic("Nil stakingKeeper!")
+	}
+	if app.slashingKeeper == nil {
+		panic("Nil slashingKeeper!")
+	}
+	if app.mintKeeper == nil {
+		panic("Nil mintKeeper!")
+	}
+	if app.distrKeeper == nil {
+		panic("Nil distrKeeper!")
+	}
+	if app.govKeeper == nil {
+		panic("Nil govKeeper!")
+	}
+	if app.crisisKeeper == nil {
+		panic("Nil crisisKeeper!")
+	}
+	if app.upgradeKeeper == nil {
+		panic("Nil upgradeKeeper!")
+	}
+	if app.paramsKeeper == nil {
+		panic("Nil paramsKeeper!")
+	}
+	if app.ibcKeeper == nil {
+		panic("Nil ibcKeeper!")
+	}
+	if app.evidenceKeeper == nil {
+		panic("Nil evidenceKeeper!")
+	}
+	if app.ibcTransferKeeper == nil {
+		panic("Nil ibcTransferKeeper!")
+	}
+	if app.gravityKeeper == nil {
+		panic("Nil gravityKeeper!")
+	}
 
 	// scoped keepers
-	if app.ScopedIBCKeeper      == nil { panic("Nil ScopedIBCKeeper!") }
-	if app.ScopedTransferKeeper == nil { panic("Nil ScopedTransferKeeper!") }
+	if app.ScopedIBCKeeper == nil {
+		panic("Nil ScopedIBCKeeper!")
+	}
+	if app.ScopedTransferKeeper == nil {
+		panic("Nil ScopedTransferKeeper!")
+	}
 
 	// managers
-	if app.mm == nil { panic("Nil ModuleManager!") }
-	if app.sm == nil { panic("Nil ModuleManager!") }
+	if app.mm == nil {
+		panic("Nil ModuleManager!")
+	}
+	if app.sm == nil {
+		panic("Nil ModuleManager!")
+	}
 }
 
 func init() {
@@ -344,11 +386,13 @@ func NewGravityApp(
 	)
 	app.bankKeeper = &bankKeeper
 
+	// distribution keeper can be nil here since it won't be used
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec,
 		keys[stakingtypes.StoreKey],
 		accountKeeper,
 		bankKeeper,
+		nil,
 		app.GetSubspace(stakingtypes.ModuleName),
 	)
 	app.stakingKeeper = &stakingKeeper

--- a/module/go.mod
+++ b/module/go.mod
@@ -26,8 +26,9 @@ require (
 	google.golang.org/grpc v1.42.0
 )
 
-replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-
-replace github.com/gogo/grpc => google.golang.org/grpc v1.33.2
-
-replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
+replace (
+	github.com/cosmos/cosmos-sdk => github.com/onomyprotocol/onomy-sdk v0.44.6-0.20220509081037-e09065c62b6b
+	github.com/gogo/grpc => google.golang.org/grpc v1.33.2
+	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
+	google.golang.org/grpc => google.golang.org/grpc v1.33.2
+)

--- a/module/go.sum
+++ b/module/go.sum
@@ -204,8 +204,6 @@ github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cosmos/btcutil v1.0.4 h1:n7C2ngKXo7UC9gNyMNLbzqz7Asuf+7Qv4gnX/rOdQ44=
 github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/TvgUaxbU=
-github.com/cosmos/cosmos-sdk v0.44.5 h1:t5h+KPzZb0Zsag1RP1DCMQlyJyIQqJcqSPJrbUCDGHY=
-github.com/cosmos/cosmos-sdk v0.44.5/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -695,6 +693,8 @@ github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXW
 github.com/olekukonko/tablewriter v0.0.2-0.20190409134802-7e037d187b0c/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
+github.com/onomyprotocol/onomy-sdk v0.44.6-0.20220509081037-e09065c62b6b h1:Ap1owf+BnVjUvkTPxYZRfLtgK1eCmCmfffe6uHdQaxg=
+github.com/onomyprotocol/onomy-sdk v0.44.6-0.20220509081037-e09065c62b6b/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=

--- a/module/x/gravity/keeper/test_common.go
+++ b/module/x/gravity/keeper/test_common.go
@@ -198,11 +198,12 @@ var (
 
 	// TestingStakeParams is a set of staking params for testing
 	TestingStakeParams = stakingtypes.Params{
-		UnbondingTime:     100,
-		MaxValidators:     10,
-		MaxEntries:        10,
-		HistoricalEntries: 10000,
-		BondDenom:         "stake",
+		UnbondingTime:           100,
+		MaxValidators:           10,
+		MaxEntries:              10,
+		HistoricalEntries:       10000,
+		BondDenom:               "stake",
+		MinGlobalSelfDelegation: sdk.ZeroInt(),
 	}
 
 	// TestingGravityParams is a set of gravity params for testing
@@ -472,7 +473,8 @@ func CreateTestEnv(t *testing.T) TestInput {
 		DefaultSendEnabled: true,
 	})
 
-	stakingKeeper := stakingkeeper.NewKeeper(marshaler, keyStaking, accountKeeper, bankKeeper, getSubspace(paramsKeeper, stakingtypes.ModuleName))
+	// distribution keeper can be nil here since it won't be used for the tests
+	stakingKeeper := stakingkeeper.NewKeeper(marshaler, keyStaking, accountKeeper, bankKeeper, nil, getSubspace(paramsKeeper, stakingtypes.ModuleName))
 	stakingKeeper.SetParams(ctx, TestingStakeParams)
 
 	distKeeper := distrkeeper.NewKeeper(marshaler, keyDistro, getSubspace(paramsKeeper, distrtypes.ModuleName), accountKeeper, bankKeeper, stakingKeeper, authtypes.FeeCollectorName, nil)


### PR DESCRIPTION
Replace cosmos-sdk with onomy-sdk v0.44.6-0.20220509081037-e09065c62b6b. 
The replacement is required for the further integration with the onomy module because the onomy-sdk contains the staking constructor updated, which makes the prev version of the gravity module incompatible with the cosmos-sdk and onomy-sdk at the same time.