### PR TITLE
Erc20 representation deployment improvements

### DIFF
--- a/module/x/gravity/keeper/attestation_handler.go
+++ b/module/x/gravity/keeper/attestation_handler.go
@@ -27,9 +27,15 @@ type AttestationHandler struct {
 
 // Check for nil members
 func (a AttestationHandler) ValidateMembers() {
-	if a.keeper     == nil { panic("Nil keeper!") }
-	if a.bankKeeper == nil { panic("Nil bankKeeper!") }
-	if a.distKeeper == nil { panic("Nil distKeeper!") }
+	if a.keeper == nil {
+		panic("Nil keeper!")
+	}
+	if a.bankKeeper == nil {
+		panic("Nil bankKeeper!")
+	}
+	if a.distKeeper == nil {
+		panic("Nil distKeeper!")
+	}
 }
 
 // SendToCommunityPool handles sending incorrect deposits to the community pool, since the deposits
@@ -201,7 +207,8 @@ func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation, claim
 		}
 		// Check if it already exists
 		existingERC20, exists := a.keeper.GetCosmosOriginatedERC20(ctx, claim.CosmosDenom)
-		if exists {
+
+		if exists && existingERC20 != nil && tokenAddress != nil && existingERC20.GetAddress() != tokenAddress.GetAddress() {
 			return sdkerrors.Wrap(
 				types.ErrInvalid,
 				fmt.Sprintf("ERC20 %s already exists for denom %s", existingERC20, claim.CosmosDenom))

--- a/orchestrator/gbt/src/client/deploy_erc20_representation.rs
+++ b/orchestrator/gbt/src/client/deploy_erc20_representation.rs
@@ -105,7 +105,7 @@ pub async fn deploy_erc20_representation(
                 }
             };
 
-            match tokio::time::timeout(Duration::from_secs(100), keep_querying_for_erc20).await {
+            match tokio::time::timeout(Duration::from_secs(1800), keep_querying_for_erc20).await {
                 Ok(_) => Ok(()),
                 Err(_) => Err(GravityError::UnrecoverableError(
                     "Your ERC20 contract was not adopted, double check the metadata and try again"

--- a/orchestrator/gbt/src/client/eth_to_cosmos.rs
+++ b/orchestrator/gbt/src/client/eth_to_cosmos.rs
@@ -76,7 +76,7 @@ pub async fn eth_to_cosmos(args: EthToCosmosOpts, prefix: String) -> Result<(), 
         }
     }
     info!(
-        "Your tokens should show up in the account {} on Gravity Bridge within 5 minutes",
+        "Your tokens should show up in the account {} on Gravity Bridge within 10 minutes",
         cosmos_dest
     );
     Ok(())


### PR DESCRIPTION
* Don't return an error if MsgERC20DeployedClaim address is the same as in the store now, to support the genesis mapping of the demon to erc20
* Increase the deploy erc20 representation timeout to 30 mins
* Set eth_to_cosmos correct time to wait